### PR TITLE
add dependency on cli

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,6 +18,7 @@ Depends:
 Imports:
   broom,
   broom.mixed,
+  cli,
   dplyr,
   metafor,
   nlme,


### PR DESCRIPTION
Closes #5.

If you wanted to be resilient to broom ever converting it's error-raising to some package other than cli, you could `@importFrom cli some_function` just to prevent the "unused package in Imports..." warning in that case, but I don't see that happening in the near term.